### PR TITLE
BUILDENV: Bumpar version till 2.0.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-def buildVersion = "2.0.3"
+def buildVersion = "2.0.4"
 
 stage('checkout') {
     node {


### PR DESCRIPTION
Med denna version kommer errorprone-varningar för JavaTimeDefaultTimeZone försvinna