### PR TITLE
INTYGFV-15018: Only use checkstyle for java files. They are anyway in…

### DIFF
--- a/src/main/resources/checkstyle/checkstyle_config_java11.xml
+++ b/src/main/resources/checkstyle/checkstyle_config_java11.xml
@@ -8,7 +8,7 @@
 
   <property name="severity" value="error"/>
 
-  <property name="fileExtensions" value="java, properties, xml"/>
+  <property name="fileExtensions" value="java"/>
 
   <module name="BeforeExecutionExclusionFileFilter">
     <property name="fileNamePattern" value="module\-info\.java$"/>


### PR DESCRIPTION
…directly excluded, because the gradle-intyg-plugin only checks main/java.